### PR TITLE
Fix: Use loopback address to address empty http response

### DIFF
--- a/packages/ligo-ui/src/Routes.tsx
+++ b/packages/ligo-ui/src/Routes.tsx
@@ -10,7 +10,7 @@ import { Search } from './reactjs/Search';
 
 let fetch =
   typeof window === 'undefined'
-    ? (path: string) => nodeFetch(`http://localhost:4000${path}`)
+    ? (path: string) => nodeFetch(`http://127.0.0.1:4000${path}`)
     : window.fetch;
 
 let routes = [


### PR DESCRIPTION
Empty response was coming from react express router

```
        debug(`Caught in react express router while resolving ${request.originalUrl}`, e);
        debug(e.message);
        debug(JSON.stringify(e));
        // @ts-ignore
--->    response.status(500).end();
```

The error caught was fetch failing to hit localhost. loopback address
instead of localhost fixes it