### PR TITLE
E2E workaround memfs

### DIFF
--- a/test/e2e-ui/config/config-scoped-e2e.yaml
+++ b/test/e2e-ui/config/config-scoped-e2e.yaml
@@ -3,16 +3,7 @@ web:
   title: verdaccio-server-e2e
   login: true
 
-store:
-  memory:
-    limit: 10
-
-auth:
-  auth-memory:
-    users:
-      test:
-        name: test
-        password: test
+storage: ./storage
 
 log: { type: stdout, format: pretty, level: info }
 

--- a/test/e2e-ui/ligo-e2e.spec.js
+++ b/test/e2e-ui/ligo-e2e.spec.js
@@ -6,6 +6,7 @@ describe('/ (Verdaccio Page)', () => {
   jest.setTimeout(20000);
 
   beforeAll(async () => {
+    await global.__SERVER__.putPackage(testPackageMetadata.name, testPackageMetadata);
     page = await global.__BROWSER__.newPage();
     await page.goto('http://localhost:55558');
     page.on('console', (msg) => console.log('PAGE LOG:', msg.text()));
@@ -28,10 +29,10 @@ describe('/ (Verdaccio Page)', () => {
     ).toContain('Search');
   });
 
-  test.skip('Search Results: should load No results', async () => {
+  test('Search Results: should load No results', async () => {
     // await page.goto('http://localhost:55558/search/a-pkg-that-doesnt-exist');
     await page.goto('http://localhost:55558/search/pk1-test');
-    let h1Handle = await page.$('h1');
+    let h1Handle = await page.$('html');
     expect(await h1Handle.evaluate((node) => node.innerText)).toContain('No results');
     // // TODO
     // //  error---  error on local search onEnd is not a function

--- a/test/e2e-ui/ligo-e2e.spec.js
+++ b/test/e2e-ui/ligo-e2e.spec.js
@@ -30,18 +30,14 @@ describe('/ (Verdaccio Page)', () => {
   });
 
   test('Search Results: should load No results', async () => {
-    // await page.goto('http://localhost:55558/search/a-pkg-that-doesnt-exist');
-    await page.goto('http://localhost:55558/search/pk1-test');
-    let h1Handle = await page.$('html');
+    await page.goto('http://localhost:55558/search/a-pkg-that-doesnt-exist');
+    let h1Handle = await page.$('h1');
     expect(await h1Handle.evaluate((node) => node.innerText)).toContain('No results');
-    // // TODO
-    // //  error---  error on local search onEnd is not a function
-    // // Not possible to test non-empty list of search results right now, because in-memory backend doesnt implement search
-    // await global.__SERVER__.putPackage(testPackageMetadata.name, testPackageMetadata);
-    // await page.reload({ waitUntil: ['networkidle0', 'domcontentloaded'] });
-    // await page.waitForTimeout(2000);
-    // h1Handle = await page.$('html');
-    // expect(await h1Handle.evaluate((node) => node.innerHTML)).toContain('No results');
+    await page.goto('http://localhost:55558/search/pk1-test');
+    h1Handle = await page.$('h1');
+    expect(await h1Handle.evaluate((node) => node.innerText)).toContain(
+      '1 results found for pk1-test'
+    );
   });
 
   test.skip('Package View: should load package Readme and other details', async () => {


### PR DESCRIPTION
e2e tests use in-memory backend so that tests are short lived. This however prevents us from running tests on features that are not fully supported by memfs - example /search

This PR uses local disk storage and enables those tests